### PR TITLE
Add preconnect hints and optimize image loading (lazy/fetchpriority/decoding)

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,10 @@
     <title>Robert Lindomar — Desenvolvedor backend e arquitetura de sistemas</title>
     <meta name="description"
         content="Desenvolvedor backend focado em APIs, microserviços e arquitetura. Java, Node.js e Rust. Microserviço de armazenamento de arquivos multi-tenant.">
+    <link rel="preconnect" href="https://cdn.tailwindcss.com">
+    <link rel="preconnect" href="https://cdnjs.cloudflare.com">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap" rel="stylesheet">
@@ -151,7 +155,7 @@
                             </div>
                             <img src="img/eu2.png" alt="Robert Lindomar"
                                 class="relative w-72 h-72 rounded-full object-cover border-4 border-white/20 shadow-2xl transform transition duration-500 group-hover:scale-105"
-                                width="288" height="288" loading="eager">
+                                width="288" height="288" loading="eager" fetchpriority="high" decoding="async">
                         </div>
                     </div>
                 </div>
@@ -278,7 +282,7 @@
                     <div
                         class="mb-6 flex aspect-square w-52 max-w-full items-center justify-center rounded-2xl bg-white/10 p-1.5 sm:w-56 sm:p-2 md:w-64 lg:w-72">
                         <img src="img/filestorage/icon.png" alt="Ícone File Storage"
-                            class="h-full w-full max-h-full max-w-full object-contain object-center">
+                            class="h-full w-full max-h-full max-w-full object-contain object-center" loading="lazy" decoding="async">
                     </div>
                     <h3 class="text-2xl font-bold text-white mb-2">File Storage Service</h3>
                     <p class="text-emerald-100/90 text-sm mb-6">Rust · API REST · armazenamento centralizado</p>
@@ -362,7 +366,7 @@
                                 <figure data-carousel-slide class="min-w-full w-full m-0">
                                     <img src="img/systagio/Dashboard.png" alt="Systagio — painel principal"
                                         class="systagio-carousel-img w-full h-auto max-h-[min(50vh,20rem)] sm:max-h-[24rem] cursor-zoom-in object-contain object-top bg-slate-900/30 transition hover:opacity-95"
-                                        width="1200" height="675" loading="eager" decoding="async">
+                                        width="1200" height="675" loading="lazy" decoding="async">
                                 </figure>
                                 <figure data-carousel-slide class="min-w-full w-full m-0">
                                     <img src="img/systagio/7-alunos.png" alt="Systagio — gestão de alunos"
@@ -522,7 +526,7 @@
                     class="bg-white rounded-xl shadow-lg overflow-hidden transform hover:scale-[1.02] transition duration-300 group flex flex-col">
                     <div class="relative overflow-hidden">
                         <img src="img/espacocarioca/capa.png" alt="Cardápio digital Espaço Carioca"
-                            class="w-full h-48 object-cover transform group-hover:scale-110 transition duration-500">
+                            class="w-full h-48 object-cover transform group-hover:scale-110 transition duration-500" loading="lazy" decoding="async">
                         <div
                             class="absolute inset-0 bg-gradient-to-t from-black/60 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300">
                         </div>
@@ -551,7 +555,7 @@
                     class="bg-white rounded-xl shadow-lg overflow-hidden transform hover:scale-[1.02] transition duration-300 group flex flex-col">
                     <div class="relative overflow-hidden">
                         <img src="img/guto/capa.png" alt="Site estúdio Arte na Pele"
-                            class="w-full h-48 object-cover transform group-hover:scale-110 transition duration-500">
+                            class="w-full h-48 object-cover transform group-hover:scale-110 transition duration-500" loading="lazy" decoding="async">
                         <div
                             class="absolute inset-0 bg-gradient-to-t from-black/60 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300">
                         </div>
@@ -579,7 +583,7 @@
                     class="bg-white rounded-xl shadow-lg overflow-hidden transform hover:scale-[1.02] transition duration-300 group flex flex-col">
                     <div class="relative overflow-hidden">
                         <img src="img/digipro/capa.png" alt="Site institucional DigiPro"
-                            class="w-full h-48 object-cover transform group-hover:scale-110 transition duration-500">
+                            class="w-full h-48 object-cover transform group-hover:scale-110 transition duration-500" loading="lazy" decoding="async">
                         <div
                             class="absolute inset-0 bg-gradient-to-t from-black/60 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300">
                         </div>
@@ -608,7 +612,7 @@
                     <div class="relative overflow-hidden">
                         <img src="img/centroempresarial/capa.png"
                             alt="Landing Centro Empresarial do Interior — Catanduva"
-                            class="w-full h-48 object-cover transform group-hover:scale-110 transition duration-500">
+                            class="w-full h-48 object-cover transform group-hover:scale-110 transition duration-500" loading="lazy" decoding="async">
                         <div
                             class="absolute inset-0 bg-gradient-to-t from-black/60 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300">
                         </div>


### PR DESCRIPTION
### Motivation
- Improve page load performance and resource fetching by hinting connections to CDNs and Google Fonts.
- Reduce initial load work and prioritize the visible hero image to improve perceived performance and Largest Contentful Paint.
- Defer decoding and network fetch for non-critical images to lower bandwidth and render work on initial load.

### Description
- Added `link rel="preconnect"` entries for `https://cdn.tailwindcss.com`, `https://cdnjs.cloudflare.com`, `https://fonts.googleapis.com` and `https://fonts.gstatic.com` (with `crossorigin`).
- Marked the hero avatar image with `fetchpriority="high"` and `decoding="async"` to prioritize and speed its decode.
- Switched several non-critical images from `loading="eager"` to `loading="lazy"` and added `decoding="async"` on carousel slides, project cards and the File Storage icon to defer work until needed.

### Testing
- No automated tests were added or executed for this change since it is a static HTML performance tweak.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de6540ea4c832aba44a91b9c5becae)